### PR TITLE
adding task to install and set ntp.

### DIFF
--- a/rhui_provision/install_v2_software.yml
+++ b/rhui_provision/install_v2_software.yml
@@ -48,6 +48,8 @@
     - include: tasks/prep_repo_install.yml
       when: iso_path == ""
 
+    - include: tasks/set_ntp.yml
+
 - name: Install Packages for RHUA
   hosts: RHUA
   user: ec2-user

--- a/rhui_provision/tasks/prep_repo_install.yml
+++ b/rhui_provision/tasks/prep_repo_install.yml
@@ -6,7 +6,7 @@
   action: yum pkg=/tmp/epel-release.rpm state=installed
 
 - name: install extra rpms to make devel env nicer
-  action: yum name=$item state=present
+  action: yum name={{ item }} state=present
   with_items:
     - vim-enhanced
     - git

--- a/rhui_provision/tasks/set_ntp.yml
+++ b/rhui_provision/tasks/set_ntp.yml
@@ -1,0 +1,5 @@
+- name: install NTPD from yum
+  action: yum name=ntp state=present
+  
+- name: enable and start NTPD
+  service: name=ntpd enabled=yes state=started


### PR DESCRIPTION
* including task during the install_v2_software playbook.
* fixing the tasks/prep_repo_install as it was failing.
* prep_repo_install is still failing, but it now installs the packages vim, git and tig and then fails while checking out rhui branch on the pup server