### PR TITLE
Add iptables rules to allow Prometheus through firewall.

### DIFF
--- a/rhui_provision/files/etc/sysconfig/iptables
+++ b/rhui_provision/files/etc/sysconfig/iptables
@@ -9,7 +9,9 @@
 -A INPUT -m state --state NEW -m tcp -p tcp --dport 80 -j ACCEPT
 -A INPUT -m state --state NEW -m tcp -p tcp --dport 443 -j ACCEPT
 -A INPUT -m state --state NEW -m tcp -p tcp --dport 5674 -j ACCEPT
+-A INPUT -m state --state NEW -m tcp -p tcp --dport 9001 -j ACCEPT
+-A INPUT -m state --state NEW -m tcp -p tcp --dport 9100 -j ACCEPT
+-A INPUT -m state --state NEW -m tcp -p tcp --dport 9117 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp-host-prohibited
 -A FORWARD -j REJECT --reject-with icmp-host-prohibited
 COMMIT
-


### PR DESCRIPTION
9001: MongoDB Exporter
9100: Node Exporter
9117: Apache Exporter