### PR TITLE
Change gofer heartbeat from 10 -> 60 seconds

### DIFF
--- a/rhui_provision/install_v2_software.yml
+++ b/rhui_provision/install_v2_software.yml
@@ -71,6 +71,7 @@
     - name: restart httpd
       action: service name=httpd state=restarted
 
+
 - name: Install Packages for CDS
   hosts: CDS_01:CDS_02
   user: ec2-user
@@ -90,15 +91,22 @@
     - name: restart httpd
       action: service name=httpd state=restarted
 
+- name: Set gofer heartbeat to 60 seconds for stability under load
+  hosts: RHUA:CDS_01:CDS_02
+  user: ec2-user
+  become: true
+
+  tasks:
+    - name: change gofer heartbeat to 60 seconds
+      shell: sed -i 's/heartbeat=10/ heartbeat=60/g' /usr/lib/python2.6/site-packages/gofer/messaging/broker.py
+
 - name: Install Packages for Monitoring
-  hosts: MON_SERV 
+  hosts: MON_SERV
   user: ec2-user
   become: true
   gather_facts: true
 
   tasks:
     - include: tasks/monitoring_service_install.yml
-    
-    - include: tasks/set_ntp.yml
 
-  
+    - include: tasks/set_ntp.yml


### PR DESCRIPTION
This change allows for more stable RHUI deploys under high load, especially when large sync jobs are occurring.